### PR TITLE
Update the GIF to use absolute path for rendering on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 A JupyterLab extension highlighting misspelled words in markdown cells within notebooks and in the text files.
 
-![](demo.gif)
+![](https://raw.githubusercontent.com/krassowski/jupyterlab-spreadsheet-editor/master/demo.gif)
 
 The JupyterLab extension is based on [the spellchecker Jupyter Notebook extension](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/spellchecker) and relies on [Typo.js](https://github.com/cfinke/Typo.js) for the actual spell checking. Spellchecker suggestions are available from the context menu.
 


### PR DESCRIPTION
Currently the demo GIF does not render on PyPI: https://pypi.org/project/jupyterlab-spellchecker/ because the path is relative. Updating the path to absolute.