### PR TITLE
Change dict loading mechanism from internal static to server extension

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,3 +31,8 @@ jobs:
 
         jupyter labextension list 2>&1 | grep -ie "@ijmbarr/jupyterlab_spellchecker.*OK"
         python -m jupyterlab.browser_check
+    - name: Install test dependencies
+      run: python -m pip install pytest
+    - name: Run python tests
+      run: |
+        python -m pytest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
-### 0.5.3 
+### 0.6.0
 - change the dictionary loading mechanism from internal static into a server extension (#69)
-- add the possibility to add custom dictionalry (#66)
+  - dictionaries will now be discovered in operating system specific paths if available
+  - choice is now possible from one of multiple dictionaries using the same locale
+- add the possibility to add custom dictionary (#66)
 
 ### 0.5.2 (2021-03-19)
 - added a status message while loading a dictionary (#62)

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ pip install -e .
 jupyter labextension develop . --overwrite
 # Rebuild extension Typescript source after making changes
 jlpm run build
+pip install pytest
 ```
 
 You can watch the source directory and run JupyterLab at the same time in different terminals to watch for changes in the extension's source and automatically rebuild the extension.
@@ -82,4 +83,10 @@ If there are any issues it might be possible to autofix them with:
 
 ```bash
 jlpm run eslint
+```
+
+Run tests:
+
+```bash
+python -m pytest
 ```

--- a/README.md
+++ b/README.md
@@ -15,7 +15,18 @@ The extension provides (Hunspell) [SCOWL](http://wordlist.aspell.net/) dictionar
 - French,
 - German (Germany, Austria, Switzerland)
 - Portuguese,
-- Spanish.
+- Spanish
+
+and will also use the Hunspell dictionaries installed in [known paths](https://github.com/jupyterlab-contrib/spellchecker/search?q=OS_SPECIFIC_PATHS) which vary by operating systems.
+If you use JupyterLab in a browser running on a different computer than the jupyter server, please note that the dictionaries need to be installed on the server machine.
+
+You can add custom dictionary by placing Hunspell files it in `dictionaries` folder in one of the `data` locations as returned by:
+
+```bash
+jupyter --paths
+```
+
+You should place two files with extensions `.aff` and `.dic`, and name following [BCP 47](https://datatracker.ietf.org/doc/html/rfc5646#section-2.1) standards.
 
 ## JupyterLab Version
 The extension has been tested up to JupyterLab version 3.0.

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ runtime:
     /home/your_name/.local/share/jupyter/runtime
 ```
 
-and you want to add Polish language, you would put `pl_PL.aff` and `pl_PL.dic` in `/home/your_name/.local/share/jupyter/dictionaries` (you will need to create this folder), so that the final structure looks similar too:
+and you want to add Polish language, you would put `pl_PL.aff` and `pl_PL.dic` in `/home/your_name/.local/share/jupyter/dictionaries` (you will need to create this folder), so that the final structure looks similar to:
 
 ```
 /home/your_name/.local/share/jupyter

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ jupyter --paths
 ```
 
 You should place two files with extensions `.aff` and `.dic`, and name following [BCP 47](https://datatracker.ietf.org/doc/html/rfc5646#section-2.1) standards.
+For more details, please see the [example](#adding-dictionaries---example) below.
 
 ## JupyterLab Version
 The extension has been tested up to JupyterLab version 3.0.
@@ -50,6 +51,52 @@ For JupyterLab 2.x:
 ```bash
 jupyter labextension install @ijmbarr/jupyterlab_spellchecker
 ```
+
+### Adding dictionaries - example
+
+If `jupyter --paths` looks like:
+
+```
+config:
+    /home/your_name/.jupyter
+    /usr/local/etc/jupyter
+    /etc/jupyter
+data:
+    /home/your_name/.local/share/jupyter
+    /usr/local/share/jupyter
+    /usr/share/jupyter
+runtime:
+    /home/your_name/.local/share/jupyter/runtime
+```
+
+and you want to add Polish language, you would put `pl_PL.aff` and `pl_PL.dic` in `/home/your_name/.local/share/jupyter/dictionaries` (you will need to create this folder), so that the final structure looks similar too:
+
+```
+/home/your_name/.local/share/jupyter
+├── dictionaries
+│   ├── pl_PL.aff
+│   └── pl_PL.dic
+├── kernels
+│   └── julia-1.5
+│       ├── kernel.json
+│       ├── logo-32x32.png
+│       └── logo-64x64.png
+├── nbconvert
+│   └── templates
+│       ├── html
+│       └── latex
+├── nbsignatures.db
+├── notebook_secret
+└── runtime
+```
+
+#### Where to get the dictionaries from?
+
+Some good sources of dictionaries include:
+- [LibreOffice/dictionaries](https://github.com/LibreOffice/dictionaries) GitHub repository
+- [Chromium](https://chromium.googlesource.com/chromium/deps/hunspell_dictionaries/+/master) repository
+- (if you know of any other quality resources please send a PR to add them here)
+
 
 ## Contributing
 

--- a/jupyterlab_spellchecker/_version.py
+++ b/jupyterlab_spellchecker/_version.py
@@ -3,6 +3,7 @@ from pathlib import Path
 
 __all__ = ["__version__"]
 
+
 def _fetchVersion():
     HERE = Path(__file__).parent.resolve()
 
@@ -14,5 +15,6 @@ def _fetchVersion():
             pass
 
     raise FileNotFoundError(f"Could not find package.json under dir {HERE!s}")
+
 
 __version__ = _fetchVersion()

--- a/jupyterlab_spellchecker/dictionaries.py
+++ b/jupyterlab_spellchecker/dictionaries.py
@@ -85,18 +85,18 @@ def _scan_for_dictionaries(data_path, log: logging.Logger):
             continue
 
         try:
-            locale_data = babel.Locale.parse(identifier)
+            locale_data = babel.Locale.parse(code)
             display_name = locale_data.get_display_name()
         except ValueError:
             display_name = base_name
             log.warning(
                 f"Could not obtain language name for {identifier} dictionary from {path}:"
-                f" {identifier} does not appear to be a valid locale identifier."
+                f" {code} does not appear to be a valid locale code."
             )
         except babel.core.UnknownLocaleError:
             log.warning(
                 f"Could not obtain language name for {identifier} dictionary from {path}:"
-                f" {identifier} is not a known locale in the installed version of babel."
+                f" {code} is not a known locale in the installed version of babel."
             )
             display_name = base_name
 

--- a/jupyterlab_spellchecker/dictionaries.py
+++ b/jupyterlab_spellchecker/dictionaries.py
@@ -1,53 +1,141 @@
-import os
-import json
-
+import logging
+import platform
+import re
 from pathlib import Path
 
+import babel
+from jupyter_core.application import JupyterApp
 from jupyter_core.paths import jupyter_path
-from notebook.utils import url_path_join
-
-def _resolve_language(dp, lang):
-    code = lang['code']
-    lang['path'] = dp
-
-    return lang
+from jupyter_server.utils import url_path_join
 
 
-def _scan_for_dictionaries(data_path):
+OS_SPECIFIC_PATHS = {
+    'Linux': [
+        '/usr/share/hunspell',
+        '/usr/share/myspell',
+        '/usr/share/myspell/dicts'
+    ],
+    'Darwin': [
+        '/System/Library/Spelling'
+    ],
+    'Windows': [
+        # TODO - contributions welcome
+    ]
+}
+
+
+def _extract_code(filename):
+    """Extract BCP 47 code identifier (tolerate small deviations from spec for user convenience).
+
+    The regular expression is not exact, but should work for most use cases
+    See: https://datatracker.ietf.org/doc/html/rfc5646#section-2.1
+    """
+    match = re.search(
+        # must start with two or three letter code
+        r'^('
+        r'(?:\w{2,3}(?=[-_]|$))'
+        # optional script (ISO 15924 code)
+        r'(?:[-_][A-Z][a-z]{3}(?=[-_]|$))?'
+        # optional region, either two letter ISO 3166-1, or three digit UN M.49
+        # e.g. "US" in "en-US", or "419" in "es-419")
+        r'(?:[-_](?:[A-Z]{2}|\d{3})(?=[-_]|$))?'
+        # optional variants (e.g. se-rozaj-biske has two variants, while de-CH-1901 has digit-defined variant see RFC)
+        r'(?:[-_](?:\w{5,8}|\d{4})(?=[-_]|$))*'
+        r')'
+        # any other suffix (not part of the match)
+        r'.*?',
+        filename
+    )
+    if match:
+        return match.group(1).replace('-', '_')
+
+
+def _scan_for_dictionaries(data_path, log: logging.Logger):
     p = Path(data_path)
-    lang_jsons = list(p.glob('**/lang.json'))
+    lang_files = list(p.glob('*.dic'))
     languages = []
-    if lang_jsons:
-        for djson in lang_jsons:
-            parent = djson.parent
-            with djson.open() as f:
-                try:
-                    data = json.load(f)
-                    if 'languages' in data:
-                        for ldata in data['languages']:
-                            lang = _resolve_language(parent, ldata)
-                            languages.append(lang)
-                    else:
-                        lang = _resolve_language(parent, data)
-                        languages.append(lang)
-                except json.JSONDecodeError as e:
-                    print(e)
+    previous_identifiers = set()
+    for dic_path in lang_files:
+        path = dic_path.parent
+
+        base_name = dic_path.name[:-4]
+
+        if base_name in previous_identifiers:
+            identifier = str(path / base_name)
+        else:
+            identifier = base_name
+        previous_identifiers.add(identifier)
+
+        code = _extract_code(base_name)
+        if code is None:
+            log.warning(
+                f"Could not recognize code for {identifier} dictionary in {path}:"
+                f" {base_name} does not match pre-specified regular expression."
+            )
+            continue
+
+        aff_path = path / (base_name + '.aff')
+
+        if not aff_path.exists():
+            log.warning(
+                f"Could not add {identifier} dictionary from {path}:"
+                f" .dic exists ({dic_path}) but could not find matching .aff file."
+            )
+            continue
+
+        try:
+            locale_data = babel.Locale.parse(identifier)
+            display_name = locale_data.get_display_name()
+        except ValueError:
+            display_name = base_name
+            log.warning(
+                f"Could not obtain language name for {identifier} dictionary from {path}:"
+                f" {identifier} does not appear to be a valid locale identifier."
+            )
+        except babel.core.UnknownLocaleError:
+            log.warning(
+                f"Could not obtain language name for {identifier} dictionary from {path}:"
+                f" {identifier} is not a known locale in the installed version of babel."
+            )
+            display_name = base_name
+
+        languages.append({
+            'path': path,
+            'code': code,
+            'id': identifier,
+            'dic': dic_path.name,
+            'aff': aff_path.name,
+            'name': display_name
+        })
     return languages
 
 
-def list_of_dictionaries():
-    data_path = jupyter_path()
-    languages = []
-    for dp in data_path:
-        languages += _scan_for_dictionaries(dp)
-    return languages
+def discover_dictionaries(server_app: JupyterApp):
+    data_paths = jupyter_path('dictionaries')
+    system = platform.system()
+    if system in OS_SPECIFIC_PATHS:
+        data_paths.extend(OS_SPECIFIC_PATHS[system])
+    # TODO: maybe use server_app.data_dir?
+
+    server_app.log.info(f"Looking for hunspell dictionaries for spellchecker in {data_paths}")
+    dictionaries = []
+    for path in data_paths:
+        dictionaries.extend(_scan_for_dictionaries(path, server_app.log))
+
+    server_app.log.info(f"Located hunspell dictionaries for spellchecker: {dictionaries}")
+    return dictionaries
 
 
-def dictionaries2url(languages, base_url):
-    for lang in languages:
-        code = lang['code'] 
-        lang['aff'] = url_path_join(base_url, code, str(lang['aff']))
-        lang['dic'] = url_path_join(base_url, code, str(lang['dic']))
-
-    return languages
-        
+def dictionaries_to_url(languages, base_url):
+    return [
+        {
+            **{
+                k: v
+                for k, v in lang.items()
+                if k not in {'path'}
+            },
+            'aff': url_path_join(base_url, lang['id'], lang['aff']),
+            'dic': url_path_join(base_url, lang['id'], lang['dic'])
+        }
+        for lang in languages
+    ]

--- a/jupyterlab_spellchecker/dictionaries.py
+++ b/jupyterlab_spellchecker/dictionaries.py
@@ -47,7 +47,7 @@ def _extract_code(filename):
         filename
     )
     if match:
-        return match.group(1).replace('-', '_')
+        return match.group(1).replace('_', '-')
 
 
 def _scan_for_dictionaries(data_path, log: logging.Logger):
@@ -73,6 +73,7 @@ def _scan_for_dictionaries(data_path, log: logging.Logger):
                 f" {base_name} does not match pre-specified regular expression."
             )
             continue
+        code = code.replace('-', '_')
 
         aff_path = path / (base_name + '.aff')
 

--- a/jupyterlab_spellchecker/handlers.py
+++ b/jupyterlab_spellchecker/handlers.py
@@ -1,48 +1,47 @@
-import os
-import json
-
-from notebook.base.handlers import APIHandler
-from notebook.utils import url_path_join
+from jupyter_server.base.handlers import APIHandler
+from jupyter_server.utils import url_path_join
 
 import tornado
 from tornado.web import StaticFileHandler
 
-from jupyter_core.paths import jupyter_path
-
-from .dictionaries import list_of_dictionaries, dictionaries2url
-
-
-lang_dictionaries = []
+from .dictionaries import discover_dictionaries, dictionaries_to_url
+from ._version import __version__
 
 
 class LanguageManagerHandler(APIHandler):
+
+    lang_dictionaries = []
+
     # The following decorator should be present on all verb methods (head, get, post,
     # patch, put, delete, options) to ensure only authorized user can request the
     # Jupyter server
     @tornado.web.authenticated
     def get(self):
-        self.finish(json.dumps(lang_dictionaries))
+        self.finish({
+            'version': __version__,
+            'dictionaries': self.lang_dictionaries
+        })
 
 
 def setup_handlers(web_app, url_path, server_app):
-    global lang_dictionaries
-
-    languages = list_of_dictionaries()
+    dictionaries = discover_dictionaries(server_app)
     host_pattern = ".*$"
     base_url = web_app.settings["base_url"]
 
     # Prepend the base_url so that it works in a JupyterHub setting
     handlers = []
-    for lang in languages:
-        lang_url = url_path_join(base_url, url_path, lang['code'])
-        #handlers.append(("{}/(.*\.((aff)|(dic)))".format(lang_url), StaticFileHandler, {"path": lang_dictionaries[lang]['path']}))
-        handlers.append(("{}/(.*)".format(lang_url),
-                        StaticFileHandler, {"path": lang['path']}))
-        lang.pop('path')  # remove unnecessary path entry
+    for lang in dictionaries:
+        lang_url = url_path_join(base_url, url_path, lang['id'])
+        handlers.append(
+            (
+                r"{}/(.*\.(?:aff|dic))".format(lang_url),
+                StaticFileHandler,
+                {"path": lang['path']}
+             )
+        )
     web_app.add_handlers(host_pattern, handlers)
 
-
-    lang_dictionaries += dictionaries2url(languages, url_path_join(base_url, url_path))
+    LanguageManagerHandler.lang_dictionaries = dictionaries_to_url(dictionaries, url_path_join(base_url, url_path))
 
     # Prepend the base_url so that it works in a JupyterHub setting
     route_pattern = url_path_join(base_url, url_path, "language_manager")

--- a/jupyterlab_spellchecker/tests/test_dictionaries.py
+++ b/jupyterlab_spellchecker/tests/test_dictionaries.py
@@ -1,0 +1,23 @@
+import pytest
+
+from jupyterlab_spellchecker.dictionaries import _extract_code
+
+
+@pytest.mark.parametrize(
+    'stripped_name, expected_code',
+    [
+        # frami matches as a variant
+        ['de_AT_frami', 'de-AT-frami'],
+        ['pl', 'pl'],
+        ['a', None],
+        ['THIS-IS-NOT-A-CODE', None],
+        ['sr-Cyrl-BA', 'sr-Cyrl-BA'],
+        ['sr-Latn-BA', 'sr-Latn-BA'],
+        ['de-CH-1901', 'de-CH-1901'],
+        ['hy-Latn-IT-arevela', 'hy-Latn-IT-arevela'],
+        ['sl-rozaj-biske', 'sl-rozaj-biske']
+    ],
+)
+def test_code_detection(stripped_name, expected_code):
+    assert _extract_code(stripped_name) == expected_code
+

--- a/jupyterlab_spellchecker/tests/test_dictionaries.py
+++ b/jupyterlab_spellchecker/tests/test_dictionaries.py
@@ -8,6 +8,7 @@ from jupyterlab_spellchecker.dictionaries import _extract_code
     [
         # frami matches as a variant
         ['de_AT_frami', 'de-AT-frami'],
+        ['en_GB-ise', 'en-GB'],
         ['pl', 'pl'],
         ['a', None],
         ['THIS-IS-NOT-A-CODE', None],

--- a/package.json
+++ b/package.json
@@ -80,10 +80,11 @@
     "discovery": {
       "server": {
         "managers": [
-          "pip"
+          "pip",
+          "conda"
         ],
         "base": {
-          "name": "jupyterlab_spellchecker"
+          "name": "jupyterlab-spellchecker"
         }
       }
     },

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -37,7 +37,7 @@
     },
     "language": {
       "title": "Language of the spellchecker",
-      "description": "Language code, e.g. en-us",
+      "description": "Dictionary identifier, e.g. en-us",
       "$ref": "#/definitions/language",
       "default": "en-us"
     },

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ labext_name = "@ijmbarr/jupyterlab_spellchecker"
 data_files_spec = [
     ("share/jupyter/labextensions/%s" % labext_name, str(lab_path), "**"),
     ("share/jupyter/labextensions/%s" % labext_name, str(HERE), "install.json"),
+    ("share/jupyter/dictionaries", str(HERE), "dictionaries/**"),
     ("etc/jupyter/jupyter_notebook_config.d", "jupyter-config/jupyter_notebook_config.d", "jupyterlab_spellchecker.json"),
     ("etc/jupyter/jupyter_server_config.d", "jupyter-config/jupyter_server_config.d", "jupyterlab_spellchecker.json"),
 ]
@@ -60,6 +61,10 @@ setup_args = dict(
     name=name,
     version=pkg_json["version"],
     url=pkg_json["homepage"],
+    project_urls={
+        'Bug Tracker': pkg_json["bugs"]["url"],
+        'Source Code': pkg_json["homepage"]
+    },
     author=pkg_json["author"]["name"],
     description=pkg_json["description"],
     license=pkg_json["license"],
@@ -68,6 +73,7 @@ setup_args = dict(
     cmdclass=cmdclass,
     packages=setuptools.find_packages(),
     install_requires=[
+        "babel",
         "jupyterlab~=3.0",
     ],
     zip_safe=False,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ labext_name = "@ijmbarr/jupyterlab_spellchecker"
 data_files_spec = [
     ("share/jupyter/labextensions/%s" % labext_name, str(lab_path), "**"),
     ("share/jupyter/labextensions/%s" % labext_name, str(HERE), "install.json"),
-    ("share/jupyter/dictionaries", str(HERE), "dictionaries/**"),
+    ("share/jupyter/dictionaries", str(HERE / "dictionaries"), "**"),
     ("etc/jupyter/jupyter_notebook_config.d", "jupyter-config/jupyter_notebook_config.d", "jupyterlab_spellchecker.json"),
     ("etc/jupyter/jupyter_server_config.d", "jupyter-config/jupyter_server_config.d", "jupyterlab_spellchecker.json"),
 ]

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,7 +105,8 @@ class LanguageManager {
       (values: ILanguageManagerResponse) => {
         console.debug('LanguageManager is ready');
         this.languages = values.dictionaries;
-    });
+      }
+    );
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,48 +57,89 @@ interface IContext {
   position: CodeMirror.Position;
 }
 
-interface ILanguage {
+/**
+ * Dictionary data defined by a pair of Hunspell .aff and .dic files.
+ * More than one dictionary may exist for a given language.
+ */
+interface IDictionary {
+  /**
+   * Identifier of the dictionary consisting of the filename without the .aff/.dic suffix
+   * and path information if needed to distinguish from other dictionaries.
+   */
+  id: string;
+  /**
+   * BCP 47 code identifier.
+   */
   code: string;
+  /**
+   * Display name, usually in the form "Language (Region)".
+   */
   name: string;
+  /**
+   * Path to the .aff file.
+   */
   aff: string;
+  /**
+   * Path to the .dic file.
+   */
   dic: string;
 }
 
+interface ILanguageManagerResponse {
+  version: string;
+  dictionaries: IDictionary[];
+}
+
 class LanguageManager {
-  languages: ILanguage[];
+  languages: IDictionary[];
 
   public ready: Promise<any>;
 
-  // initialise the manager
-  // mainly reading the definitions from the external extension
+  /**
+   * initialise the manager
+   * mainly reading the definitions from the external extension
+   */
   constructor() {
     // read the list of languages from the external extension
-    this.ready = requestAPI<any>('language_manager').then(values => {
-      console.debug('LanguageManager is ready');
-      this.languages = values;
+    this.ready = requestAPI<any>('language_manager').then(
+      (values: ILanguageManagerResponse) => {
+        console.debug('LanguageManager is ready');
+        this.languages = values.dictionaries;
     });
   }
 
-  // get an array of languages, put "language" in front of the list
-  // the list is alphabetically sorted
-  getchoices(language: ILanguage) {
+  /**
+   * get an array of languages, put "language" in front of the list
+   * the list is alphabetically sorted
+   */
+  getChoices(language: IDictionary) {
     return [
       language,
       ...this.languages
-        .filter(l => l.name !== language.name)
+        .filter(l => l.id !== language.id)
         .sort((a, b) => a.name.localeCompare(b.name))
     ];
   }
 
-  // select the language by the name entry
-  getlanguagebyname(name: string) {
-    return this.languages.filter(l => l.name === name)[0];
-  }
-
-  // select the language by the code entry
-  // code was read by settings, so the type is not specifies -> any
-  getlanguagebycode(code: string | any) {
-    return this.languages.filter(l => l.code === code)[0];
+  /**
+   * select the language by the identifier
+   */
+  getLanguageByIdentifier(identifier: string): IDictionary | undefined {
+    const exactMatch = this.languages.find(l => l.id === identifier);
+    if (exactMatch) {
+      return exactMatch;
+    }
+    // approximate matches support transition from the 0.5 version (and older)
+    // that used incorrect codes as language identifiers
+    const approximateMatch = this.languages.find(
+      l => l.id.toLowerCase() === identifier.replace('-', '_').toLowerCase()
+    );
+    if (approximateMatch) {
+      console.warn(
+        `Language identifier ${identifier} has a non-exact match, please update it to ${approximateMatch.id}`
+      );
+      return approximateMatch;
+    }
   }
 }
 
@@ -126,7 +167,7 @@ class SpellChecker {
 
   // Default Options
   check_spelling = true;
-  language: ILanguage;
+  language: IDictionary;
   language_manager: LanguageManager;
   rx_word_char = /[^-[\]{}():/!;&@$£%§<>"*+=?.,~\\^|_`#±\s\t]/;
   rx_non_word_char = /[-[\]{}():/!;&@$£%§<>"*+=?.,~\\^|_`#±\s\t]/;
@@ -204,12 +245,11 @@ class SpellChecker {
     this._set_theme(theme);
 
     // read the saved language setting
-    const language_code = settings.get('language').composite;
-    const user_language = this.language_manager.getlanguagebycode(
-      language_code
-    );
+    const language_id = settings.get('language').composite as string;
+    const user_language =
+      this.language_manager.getLanguageByIdentifier(language_id);
     if (user_language === undefined) {
-      console.warn('The language ' + language_code + ' is not supported!');
+      console.warn('The language ' + language_id + ' is not supported!');
     } else {
       this.language = user_language;
       // load the dictionary
@@ -461,11 +501,7 @@ class SpellChecker {
       fetch(this.language.dic).then(res => res.text())
     ]).then(values => {
       this.dictionary = new Typo(this.language.name, values[0], values[1]);
-      console.debug(
-        'Dictionary Loaded ',
-        this.language.name,
-        this.language.code
-      );
+      console.debug('Dictionary Loaded ', this.language.name, this.language.id);
 
       this.status_msg = this.language.name;
       // update the complete UI
@@ -521,16 +557,32 @@ class SpellChecker {
   }
 
   choose_language() {
-    const choices = this.language_manager.getchoices(this.language);
+    const choices = this.language_manager.getChoices(this.language);
+
+    const choiceStrings = choices.map(
+      // note: two dictionaries may exist for a language with the same name,
+      // so we append the actual id of the dictionary in the square brackets.
+      dictionary => dictionary.name + ' [' + dictionary.id + ']'
+    );
 
     InputDialog.getItem({
       title: 'Choose spellchecker language',
-      items: choices.map(language => language.name)
+      items: choiceStrings
     }).then(value => {
       if (value.value !== null) {
-        this.language = this.language_manager.getlanguagebyname(value.value);
+        const index = choiceStrings.indexOf(value.value);
+        const lang = this.language_manager.getLanguageByIdentifier(
+          choices[index].id
+        );
+        if (!lang) {
+          console.error(
+            'Language could not be matched - please report this as an issue'
+          );
+          return;
+        }
+        this.language = lang;
         // the setup routine will load the dictionary
-        this.settings.set('language', this.language.code).catch(console.warn);
+        this.settings.set('language', this.language.id).catch(console.warn);
       }
     });
   }


### PR DESCRIPTION
Builds upon #70

Closes #31

- dictionaries now have an ID allowing to distinguish multiple dictionaries from different locations for the same language/code
- OS-specific locations are now searched to discover pre-installed dictionaries
- use `babel` to resolve the language/locale name for given locale code (as it is already a dependency of JupyterLab) - we can revisit this in the future

In the follow up PR: split the existing dictionaries into separate packages so that one does not need to install the dictionaries they don't need