### PR TITLE
Release v0.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 0.7.0 (2021-07-31)
+- added possibility of using remote "online" dictionaries by specifying URLs for `.aff` and `.dic` files (#85)
+- added support for translations of the text shown in the interface (#84)
+- fixed the behaviour of the dictionary selector when an invalid dictionary is initially set in the settings (#83)
+- bumped normalize-uri to 4.5.1 (#82)
+- enable strict null checks, switch to modern compilation targets; add more Jupyter projects to spellcheck ignore (#86)
+
 ### 0.6.0 (2021-06-01)
 - change the dictionary loading mechanism from internal static into a server extension (#69)
   - dictionaries will now be discovered in operating system specific paths if available

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ijmbarr/jupyterlab_spellchecker",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "A spell checker for JupyterLab.",
   "keywords": [
     "jupyter",


### PR DESCRIPTION
Preparations for 0.7.0 release. I will leave it there for 24 hours and if there are no comments I will proceed with the release.

To view all commits to be included in this release see: https://github.com/jupyterlab-contrib/spellchecker/compare/v0.6.0...krassowski:v0.7.0