### PR TITLE
Fallback to `base_name` if babel crashes

### DIFF
--- a/jupyterlab_spellchecker/dictionaries.py
+++ b/jupyterlab_spellchecker/dictionaries.py
@@ -99,6 +99,12 @@ def _scan_for_dictionaries(data_path, log: logging.Logger):
                 f" {code} is not a known locale in the installed version of babel."
             )
             display_name = base_name
+        except Exception as e:
+            log.warning(
+                f"Could not obtain language name for {identifier} dictionary from {path}:"
+                f" {code} crashed babel: {e}."
+            )
+            display_name = base_name
 
         languages.append({
             'path': path,


### PR DESCRIPTION
Prevents crash as seen in #94 due to an upstream bug.