### PR TITLE
Enable spellchecker by default in RST and LaTeX files

### DIFF
--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -77,7 +77,8 @@
       "$ref": "#/definitions/mimeTypes",
       "default": [
         "text/plain",
-        "text/x-ipythongfm"
+        "text/x-ipythongfm",
+        "text/x-rst"
       ]
     },
     "onlineDictionaries": {

--- a/schema/plugin.json
+++ b/schema/plugin.json
@@ -78,7 +78,8 @@
       "default": [
         "text/plain",
         "text/x-ipythongfm",
-        "text/x-rst"
+        "text/x-rst",
+        "text/x-latex"
       ]
     },
     "onlineDictionaries": {


### PR DESCRIPTION
Closes #102.

We may decide to walk back on these choices depending on the community feedback, but in general it is easier for user to remove the mimetype using settings than find out what the should type in.