### PR TITLE
Hard-code URLs to fix PyPI upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
+### 0.8.1 (2023-06-04)
+
+- fix for PyPI upload (#130)
+
 ### 0.8.0 (2023-06-04)
 
 - support JupyterLab 4.0 (#128)
+- support optional spellchecking in comments and strings
+- click on statusbar item to enable spellchecking
 
 ### 0.7.3 (2023-02-08)
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ For more details, please see the [example](#adding-dictionaries---example) below
 
 ## JupyterLab Version
 
-The extension has been tested up to JupyterLab version 3.0.
+The extension has been tested up to JupyterLab version 4.0.
 
 ## Installation
 
-For JupyterLab 3.x:
+For JupyterLab 3.x and 4.x:
 
 ```bash
 pip install jupyterlab-spellchecker

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,13 +24,17 @@ classifiers = [
 dependencies = [
     "jupyter_server>=2.0.1,<3"
 ]
-dynamic = ["version", "description", "authors", "urls", "keywords"]
+dynamic = ["version", "description", "authors", "keywords"]
+
+[project.urls]
+Source = "https://github.com/jupyterlab-contrib/spellchecker"
+Issues = "https://github.com/jupyterlab-contrib/spellchecker/issues"
 
 [tool.hatch.version]
 source = "nodejs"
 
 [tool.hatch.metadata.hooks.nodejs]
-fields = ["description", "authors", "urls"]
+fields = ["description", "authors"]
 
 [tool.hatch.build.targets.sdist]
 artifacts = ["jupyterlab_spellchecker/labextension"]


### PR DESCRIPTION
Upload to PyPI failed due to a faulty URL. This simplifies the setup by not using dynamic field for URLs.

Verified to work well on Test PyPI: https://test.pypi.org/project/jupyterlab-spellchecker/0.8.0/