### PR TITLE
Fix dictionaries location, improve UI, support comments in C-like languages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+### 0.8.3 (2023-06-05)
+
+- bug fixes:
+  - fix old status persisting in status bar when switching editors (but not typing anything yet)
+  - fix dictionaries not being copied over on install
+- enhancements:
+  - spellcheck in block comments
+  - show language in the dialog for enabling spellcheck in current document
+
 ### 0.8.2 (2023-06-04)
 
 - fix server extension loading (#131)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 - bug fixes:
   - fix old status persisting in status bar when switching editors (but not typing anything yet)
   - fix dictionaries not being copied over on install
+  - spellcheck in block comments and line comments in languages with C-like syntax
 - enhancements:
-  - spellcheck in block comments
   - show language in the dialog for enabling spellcheck in current document
 
 ### 0.8.2 (2023-06-04)

--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ A JupyterLab extension highlighting misspelled words in markdown cells within no
 The JupyterLab extension is based on [the spellchecker Jupyter Notebook extension](https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/spellchecker) and relies on [Typo.js](https://github.com/cfinke/Typo.js) for the actual spell checking.
 Spellchecker suggestions are available from the context menu. The style of the highlights can be customized in the _Advanced Settings Editor_.
 
+You can click on the status bar item to:
+
+- change language
+- enable spelling in the current document
+
+Spellchecking in comments and strings in code can be configured in settings.
+
 The extension provides (Hunspell) [SCOWL](http://wordlist.aspell.net/) dictionaries for:
 
 - American, British, Canadian, and Australian English

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupyterlab-contrib/spellchecker",
-  "version": "0.8.2",
+  "version": "0.8.3",
   "description": "A spell checker for JupyterLab.",
   "keywords": [
     "jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ exclude = [".github", "binder"]
 "install.json" = "share/jupyter/labextensions/@jupyterlab-contrib/spellchecker/install.json"
 "jupyter-config/server-config" = "etc/jupyter/jupyter_server_config.d"
 "jupyter-config/nb-config" = "etc/jupyter/jupyter_notebook_config.d"
+"dictionaries" = "share/jupyter/dictionaries"
 
 [tool.hatch.build.hooks.version]
 path = "jupyterlab_spellchecker/_version.py"

--- a/src/index.ts
+++ b/src/index.ts
@@ -308,6 +308,11 @@ class SpellChecker {
             }
 
             const content = [...view.state.sliceDoc(0, view.state.doc.length)];
+            const commentTypes = new Set([
+              'comment', // Python
+              'blockcomment', // C-like languages
+              'linecomment' // C-like languages
+            ]);
 
             tree.iterate({
               mode: IterMode.IncludeAnonymous,
@@ -317,9 +322,7 @@ class SpellChecker {
                 if (isLeaf) {
                   const nodeType = node.name.toLowerCase();
                   if (
-                    (checkComments &&
-                      (nodeType === 'comment' ||
-                        nodeType === 'blockcomment')) ||
+                    (checkComments && commentTypes.has(nodeType)) ||
                     (checkStrings && nodeType === 'string') ||
                     (isPlain && nodeType === '⚠') ||
                     nodeType === 'paragraph' ||

--- a/src/index.ts
+++ b/src/index.ts
@@ -317,7 +317,9 @@ class SpellChecker {
                 if (isLeaf) {
                   const nodeType = node.name.toLowerCase();
                   if (
-                    (checkComments && nodeType === 'comment') ||
+                    (checkComments &&
+                      (nodeType === 'comment' ||
+                        nodeType === 'blockcomment')) ||
                     (checkStrings && nodeType === 'string') ||
                     (isPlain && nodeType === '⚠') ||
                     nodeType === 'paragraph' ||


### PR DESCRIPTION
This PR combines a few fixes for issues caught after 0.8.2 release.

- bug fixes:
  - fix old status persisting in status bar when switching editors (but not typing anything yet)
  - fix dictionaries not being copied over on install
  - spellcheck in block comments and line comments in languages with C-like syntax
- enhancements:
  - show language in the dialog for enabling spellcheck in current document