### PR TITLE
Use public API of CodeMirror's `EditorView` to find view from DOM

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -486,7 +486,7 @@ class SpellChecker {
     if (code_mirror_wrapper === null) {
       return null;
     }
-    const editorView = code_mirror_wrapper.cmView.view as EditorView;
+    const editorView = EditorView.findFromDOM(code_mirror_wrapper);
     const offset = editorView.posAtCoords({
       x: event.clientX,
       y: event.clientY

--- a/src/index.ts
+++ b/src/index.ts
@@ -487,6 +487,9 @@ class SpellChecker {
       return null;
     }
     const editorView = EditorView.findFromDOM(code_mirror_wrapper);
+    if (!editorView) {
+      return null;
+    }
     const offset = editorView.posAtCoords({
       x: event.clientX,
       y: event.clientY


### PR DESCRIPTION
This required to make spellchecker work with new versions of CodeMirror:
- https://github.com/jupyterlab/jupyterlab/pull/18344
- https://github.com/jupyterlab/jupyterlab/pull/18366