### PR TITLE
Refresh CI workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,25 +11,34 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v3
+      uses: actions/checkout@v7
     - name: Install node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
-       node-version: '16.x'
+        node-version: '20.x'
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.8'
+        python-version: '3.11'
         architecture: 'x64'
-    - name: Install dependencies
-      run: python -m pip install jupyterlab
-    - name: Build the extension
+    - name: Install Python dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install 'jupyterlab>=4,<5'
+    - name: Install JavaScript dependencies
       run: |
         jlpm
+    - name: Lint
+      run: |
         jlpm run lint:check
+    - name: Install extension
+      run: |
         python -m pip install .
-
+    - name: Check labextension
+      run: |
         jupyter labextension list 2>&1 | grep -ie "@jupyterlab-contrib/spellchecker.*OK"
+    - name: Browser smoke test
+      run: |
         python -m jupyterlab.browser_check
     - name: Install test dependencies
       run: python -m pip install pytest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,19 +9,19 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v7
     - name: Install node
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
-        node-version: '16.x'
+        node-version: '20.x'
         registry-url: 'https://registry.npmjs.org'
     - name: Install Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6
       with:
-        python-version: '3.8'
+        python-version: '3.11'
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip build twine jupyterlab
+        python -m pip install --upgrade pip build twine 'jupyterlab>=4,<5'
     - name: Build the federated extension in a separated build environment
       run: |
         python -m build

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "build:prod": "jlpm clean && jlpm build:lib:prod && jlpm build:labextension",
     "clean": "jlpm clean:lib",
     "clean:all": "jlpm clean:lib && jlpm clean:labextension && jlpm clean:lintcache",
-    "clean:labextension": "rimraf jupyterlab-spellchecker/labextension jupyterlab-spellchecker/_version.py",
+    "clean:labextension": "rimraf jupyterlab_spellchecker/labextension jupyterlab_spellchecker/_version.py",
     "clean:lib": "rimraf lib tsconfig.tsbuildinfo",
     "clean:lintcache": "rimraf .eslintcache .stylelintcache",
     "eslint": "jlpm eslint:check --fix",


### PR DESCRIPTION
This refreshes the CI and publish workflows by updating GitHub Actions, Node, and Python versions, and makes the build workflow easier to follow by separating dependency installation, linting, extension installation, labextension validation, and the existing JupyterLab browser smoke check. It also fixes the `clean:labextension` path so generated files are cleaned from the correct `jupyterlab_spellchecker` package directory